### PR TITLE
Configure release signing fallback

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,8 @@ plugins {
 
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
-if (keystorePropertiesFile.exists()) {
+def hasReleaseKeystore = keystorePropertiesFile.exists()
+if (hasReleaseKeystore) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
 
@@ -27,12 +28,14 @@ android {
     }
 
     signingConfigs {
-       release {
-           keyAlias keystoreProperties['keyAlias']
-           keyPassword keystoreProperties['keyPassword']
-           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
-           storePassword keystoreProperties['storePassword']
-       }
+        if (hasReleaseKeystore) {
+            release {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+                storePassword keystoreProperties['storePassword']
+            }
+        }
     }
 
     defaultConfig {
@@ -48,9 +51,9 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.release
+            // Use the configured release keystore when available, otherwise fall back to the
+            // debug signing config so development builds continue to work.
+            signingConfig = hasReleaseKeystore ? signingConfigs.release : signingConfigs.debug
         }
     }
 }

--- a/architecture.md
+++ b/architecture.md
@@ -54,6 +54,23 @@ Aplicación móvil para turismo responsable en veredas que permite a los usuario
 ### Android
 - Permisos de ubicación en AndroidManifest.xml
 - Configuración para Google Maps API
+- Firma de releases mediante keystore dedicado
+
+#### Firma de releases
+1. Genera un keystore para producción dentro de `android/app` (por ejemplo `android/app/release-keystore.jks`) con el siguiente comando:
+   ```bash
+   keytool -genkey -v -keystore android/app/release-keystore.jks -alias upload -keyalg RSA -keysize 2048 -validity 10000
+   ```
+2. Crea el archivo `android/key.properties` (no debe versionarse) con el contenido:
+   ```properties
+   storePassword=TU_PASSWORD_DEL_KEYSTORE
+   keyPassword=TU_PASSWORD_DE_LA_LLAVE
+   keyAlias=upload
+   storeFile=../app/release-keystore.jks
+   ```
+3. Guarda estos archivos en un lugar seguro y comparte las contraseñas solo con las personas autorizadas para publicar releases oficiales.
+
+Cuando `key.properties` no está presente, la app reutiliza automáticamente la firma de depuración para facilitar el desarrollo local.
 
 ### iOS
 - Descripción de uso de ubicación en Info.plist


### PR DESCRIPTION
## Summary
- conditionally configure the release signing config only when a keystore is present and fall back to debug signing otherwise
- document how to generate a release keystore and matching key.properties for official builds

## Testing
- flutter build apk --release *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9b7b5218832da22ea005d9197002