### PR TITLE
Configure Google Maps API key provisioning

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,27 @@ plugins {
 }
 
 
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localProperties.load(new FileInputStream(localPropertiesFile))
+}
+
+def mapsApiKey = [
+    project.hasProperty('MAPS_API_KEY') ? project.property('MAPS_API_KEY') : null,
+    localProperties.getProperty('MAPS_API_KEY'),
+    System.getenv('MAPS_API_KEY')
+].find { candidate ->
+    candidate != null && !candidate.toString().trim().isEmpty()
+}
+if (mapsApiKey == null) {
+    logger.warn("MAPS_API_KEY is not defined. Google Maps will not load without a valid key.")
+    mapsApiKey = ""
+} else {
+    mapsApiKey = mapsApiKey.toString()
+}
+
+
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 def hasReleaseKeystore = keystorePropertiesFile.exists()
@@ -47,6 +68,7 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        manifestPlaceholders = (manifestPlaceholders ?: [:]) + [MAPS_API_KEY: mapsApiKey]
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
             android:name="flutterEmbedding"
             android:value="2" />
         <meta-data android:name="com.google.android.geo.API_KEY"
-                   android:value="YOUR_API_KEY_HERE"/>
+                   android:value="${MAPS_API_KEY}"/>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/architecture.md
+++ b/architecture.md
@@ -56,6 +56,22 @@ Aplicación móvil para turismo responsable en veredas que permite a los usuario
 - Configuración para Google Maps API
 - Firma de releases mediante keystore dedicado
 
+#### Clave de API de Google Maps
+1. Ingresa a [Google Cloud Console](https://console.cloud.google.com/) con una cuenta autorizada y selecciona el proyecto del cliente. Si no existe, crea uno nuevo para la aplicación **Sendero Seguro**.
+2. Habilita los servicios necesarios desde **APIs & Services > Library**:
+   - **Maps SDK for Android** (obligatorio para mostrar mapas).
+   - Opcionalmente **Geocoding API** o **Places API** si se requieren en futuras iteraciones.
+3. Crea una credencial tipo **API key** en **APIs & Services > Credentials** y aplícale restricciones:
+   - **Application restrictions**: selecciona *Android apps* y registra el `applicationId` (`com.mycompany.CounterApp`) junto con la huella SHA-1 de los certificados de firma (debug y release si aplica).
+   - **API restrictions**: limita la llave únicamente a las APIs habilitadas en el paso anterior.
+4. Copia la clave generada en el archivo `android/local.properties` (no versionado) con el formato:
+   ```properties
+   MAPS_API_KEY=tu_clave_aqui
+   ```
+   Alternativamente, puedes exponerla como variable de entorno (`MAPS_API_KEY`) o pasarla al invocar Gradle (`./gradlew assembleDebug -PMAPS_API_KEY=...`).
+5. Verifica el aprovisionamiento ejecutando `./gradlew :app:processDebugMainManifest` y comprobando que el valor se refleje en el manifest generado. Si la clave no está definida, Gradle emite una advertencia y el mapa cargará sin credenciales.
+6. Comparte la clave de manera segura y evita publicarla en repositorios o sistemas de seguimiento de tickets.
+
 #### Firma de releases
 1. Genera un keystore para producción dentro de `android/app` (por ejemplo `android/app/release-keystore.jks`) con el siguiente comando:
    ```bash


### PR DESCRIPTION
## Summary
- load the Google Maps API key from Gradle/local properties and expose it through manifest placeholders
- replace the hardcoded API key in the Android manifest with the Gradle-provided placeholder
- document the steps required to provision and secure the Google Maps API key for new environments

## Testing
- ⚠️ `flutter analyze` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9c8de574832d9d1d9890d7e754bf