### PR TITLE
Bump Android Gradle plugin to 8.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22'
     }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.1.1" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 


### PR DESCRIPTION
## Summary
- bump the Android application plugin version declared in `android/settings.gradle` to 8.1.1
- align the Android Gradle buildscript classpath in `android/build.gradle` to use version 8.1.1 as well

## Testing
- ⚠️ `flutter clean` *(fails: flutter command not available in container environment)*
- ⚠️ `cd android && ./gradlew assembleDebug` *(fails: gradlew wrapper script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4fb00aec832db508627971c68c64